### PR TITLE
BAH-4118 | Fix. Validation for mobile verification while ABHA creation

### DIFF
--- a/src/components/creation/VerifyOTPAndCreateABHA.jsx
+++ b/src/components/creation/VerifyOTPAndCreateABHA.jsx
@@ -49,7 +49,7 @@ const VerifyOTPAndCreateABHA = (props) => {
 		} else {
 			let abhaProfile = response.data.abhaProfile;
 			setPatient(response.data.abhaProfile);
-			if (abhaProfile.mobile === null) {
+			if (!abhaProfile.mobile) {
 				setRequireMobileVerification(true);
 			} else {
 				setIsMobileVerified(true);


### PR DESCRIPTION
This PR is a minor fix which enhances the validation for `mobile` field of the response for verifyOtpAndCreateABHA API reposnse. This handles the cases with mobile field being null or undefined