### PR TITLE
BAH-4137 | Fix. Enable resend OTP only when OTP response is success

### DIFF
--- a/src/api/apiUtils.js
+++ b/src/api/apiUtils.js
@@ -9,27 +9,8 @@ export const parseAPIError = (error) => {
     if (errorResponseData instanceof Array){
         errorResponseData = errorResponseData[0];
     }
-    if (errorResponseData.message)
-    {
-        errorObject.error.message = errorResponseData.message;
-        return errorObject;
-    }
-    if (errorResponseData.error?.message)
-    {
-        errorObject.error.message = errorResponseData.error.message;
-        return errorObject;
-    }
-    if (errorResponseData.details !== undefined && errorResponseData.details.length > 0){
-        errorObject.error.message = errorResponseData.details[0].message;
-        return errorObject;
-    }
-    if (errorResponseData.error !== undefined && typeof errorResponseData.error === 'string')
-    {
-        errorObject.error.message = errorResponseData.error;
-        return errorObject;
-    }
-    let extractedErrorMessage = extractErrorMessage(errorResponseData)
-    if (extractedErrorMessage !== undefined)
+    let extractedErrorMessage = extractErrorMessageFromPayload(errorResponseData)
+    if (extractedErrorMessage)
     {
         errorObject.error.message = extractedErrorMessage;
         return errorObject;
@@ -47,7 +28,13 @@ export const parseAPIError = (error) => {
     return errorObject;
 }
 
-const extractErrorMessage = (errorResponseData) => {
+const extractErrorMessageFromPayload = (errorResponseData) => {
+    let errorMessage =  errorResponseData?.message || errorResponseData?.error?.message || errorResponseData?.details?.[0]?.message;
+    if(errorMessage)
+        return errorMessage
+    if (typeof errorResponseData?.error === 'string') {
+        return errorResponseData.error;
+    }
     if (typeof errorResponseData === 'object')
         for (var key in errorResponseData) {
             if (key !== 'timestamp') {

--- a/src/api/apiUtils.js
+++ b/src/api/apiUtils.js
@@ -3,26 +3,48 @@ export const parseAPIError = (error) => {
     if (!error.response?.data) {
         return Constants.serviceUnavailableError;
     }
+    var errorObject = { "error": { "message": "An error occurred while processing your request", "status": error.response.status}}
+
     var errorResponseData = error.response.data;
     if (errorResponseData instanceof Array){
         errorResponseData = errorResponseData[0];
     }
     if (errorResponseData.message)
-        return { "error": { "message": errorResponseData.message } }
+    {
+        errorObject.error.message = errorResponseData.message;
+        return errorObject;
+    }
     if (errorResponseData.error?.message)
-        return { "error": { "message": errorResponseData.error.message } }
-    if (errorResponseData.details !== undefined && errorResponseData.details.length > 0)
-        return { "error": { "message": errorResponseData.details[0].message } }
+    {
+        errorObject.error.message = errorResponseData.error.message;
+        return errorObject;
+    }
+    if (errorResponseData.details !== undefined && errorResponseData.details.length > 0){
+        errorObject.error.message = errorResponseData.details[0].message;
+        return errorObject;
+    }
     if (errorResponseData.error !== undefined && typeof errorResponseData.error === 'string')
-        return { "error": { "message": errorResponseData.error } }
+    {
+        errorObject.error.message = errorResponseData.error;
+        return errorObject;
+    }
     let extractedErrorMessage = extractErrorMessage(errorResponseData)
     if (extractedErrorMessage !== undefined)
-        return extractedErrorMessage
-    if (error.status === 400)
-        return { "error": { "message": "Bad Request: Please verify the entered input" } }
-    if (error.status === 500)
-        return { "error": { "message": "Internal Server Error: Please try again later" } }
-    return { "error": { "message": "An error occurred while processing your request" } }
+    {
+        errorObject.error.message = extractedErrorMessage;
+        return errorObject;
+    }
+    if (error.response.status === 400)
+    {
+        errorObject.error.message = "Bad Request: Please verify the entered input";
+        return errorObject;
+    }
+    if (error.response.status === 500)
+    {
+        errorObject.error.message = "Internal Server Error: Please try again later";
+        return errorObject;
+    }
+    return errorObject;
 }
 
 const extractErrorMessage = (errorResponseData) => {

--- a/src/components/creation/VerifyMobile.jsx
+++ b/src/components/creation/VerifyMobile.jsx
@@ -31,11 +31,11 @@ const VerifyMobile = (props) => {
 			setLoader(true);
 			var response = await generateMobileOtp(mobile);
 			setLoader(false);
-            setshowResendOtp(true);
 			if (response.error) {
-				setError(response.error.message);
+                setError(response.error.message);
 			}
             else{
+                setshowResendOtp(true);
                 setShowOtpInput(true);
             }
 		}
@@ -46,6 +46,8 @@ const VerifyMobile = (props) => {
 			var response = await generateMobileOtp(mobile);
 			setLoader(false);
 			if (response.error) {
+                if(response.error.status === 429)
+                    setshowResendOtp(false);
 				setError(response.error.message);
 			}
             else{

--- a/src/components/creation/VerifyMobile.jsx
+++ b/src/components/creation/VerifyMobile.jsx
@@ -15,7 +15,7 @@ const VerifyMobile = (props) => {
     const [proceed, setProceed] = useState(false);
     const [otp, setOtp] = useState('');
     const [otpVerified, setOtpVerified] = useState(false);
-    const [showResendOtp, setshowResendOtp] = useState(false);
+    const [showResendOtp, setShowResendOtp] = useState(false);
     const [showResendSuccessMessage,setShowResendSuccessMessage] = useState(false);
 
 
@@ -35,7 +35,7 @@ const VerifyMobile = (props) => {
                 setError(response.error.message);
 			}
             else{
-                setshowResendOtp(true);
+                setShowResendOtp(true);
                 setShowOtpInput(true);
             }
 		}
@@ -47,7 +47,7 @@ const VerifyMobile = (props) => {
 			setLoader(false);
 			if (response.error) {
                 if(response.error.status === 429)
-                    setshowResendOtp(false);
+                    setShowResendOtp(false);
 				setError(response.error.message);
 			}
             else{
@@ -57,7 +57,7 @@ const VerifyMobile = (props) => {
 		}
 
     async function verifyOtp() {
-        if (otp === '') {
+        if (!otp.trim()) {
             setError("otp cannot be empty")
         } else {
             setLoader(true);


### PR DESCRIPTION
This PR fixes the issue with Resend OTP button being enabled even though an error was thrown by the request OTP API.